### PR TITLE
Support arm64-darwin-22 platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ GEM
     docile (1.4.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    nokogiri (1.16.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
@@ -78,6 +80,7 @@ GEM
     yard (0.9.36)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin
   x86_64-linux
 


### PR DESCRIPTION
Using `macos-latest` with GitHub-hosted runners will now runs the actions on an Apple M1 CPU, and Bundler needs to know about it:

> Your bundle only supports platforms ["x86_64-darwin", "x86_64-linux"]
> but your local platform is arm64-darwin-22. Add the current platform
> to the lockfile with `bundle lock --add-platform arm64-darwin-22` and
> try again.

See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories