### PR TITLE
Prefer Hash-based code_data

### DIFF
--- a/lib/sheetah/headers.rb
+++ b/lib/sheetah/headers.rb
@@ -55,7 +55,7 @@ module Sheetah
 
         missing_columns.each do |column|
           @messenger.error(
-            Messaging::Messages::MissingColumn.new(code_data: column.header)
+            Messaging::Messages::MissingColumn.new(code_data: { value: column.header })
           )
         end
       end
@@ -75,7 +75,7 @@ module Sheetah
       unless @specification.ignore_unspecified_columns?
         @failure = true
         @messenger.error(
-          Messaging::Messages::InvalidHeader.new(code_data: header.value)
+          Messaging::Messages::InvalidHeader.new(code_data: { value: header.value })
         )
       end
 
@@ -87,7 +87,7 @@ module Sheetah
 
       @failure = true
       @messenger.error(
-        Messaging::Messages::DuplicatedHeader.new(code_data: header.value)
+        Messaging::Messages::DuplicatedHeader.new(code_data: { value: header.value })
       )
 
       false

--- a/lib/sheetah/messaging/messages/duplicated_header.rb
+++ b/lib/sheetah/messaging/messages/duplicated_header.rb
@@ -12,7 +12,7 @@ module Sheetah
           col
 
           def validate_code_data(message)
-            message.code_data.is_a?(String)
+            message.code_data in { value: String }
           end
         end
       end

--- a/lib/sheetah/messaging/messages/invalid_header.rb
+++ b/lib/sheetah/messaging/messages/invalid_header.rb
@@ -12,7 +12,7 @@ module Sheetah
           col
 
           def validate_code_data(message)
-            message.code_data.is_a?(String)
+            message.code_data in { value: String }
           end
         end
       end

--- a/lib/sheetah/messaging/messages/missing_column.rb
+++ b/lib/sheetah/messaging/messages/missing_column.rb
@@ -12,7 +12,7 @@ module Sheetah
           sheet
 
           def validate_code_data(message)
-            message.code_data.is_a?(String)
+            message.code_data in { value: String }
           end
         end
       end

--- a/spec/sheetah/headers_spec.rb
+++ b/spec/sheetah/headers_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Sheetah::Headers, monadic_result: true do
           be_a(Sheetah::Messaging::Message) & have_attributes(
             severity: "ERROR",
             code: "invalid_header",
-            code_data: sheet_headers[4].value,
+            code_data: { value: sheet_headers[4].value },
             scope: "COL",
             scope_data: { col: sheet_headers[4].col }
           )
@@ -122,7 +122,7 @@ RSpec.describe Sheetah::Headers, monadic_result: true do
           be_a(Sheetah::Messaging::Message) & have_attributes(
             severity: "ERROR",
             code: "duplicated_header",
-            code_data: sheet_headers[1].value,
+            code_data: { value: sheet_headers[1].value },
             scope: "COL",
             scope_data: { col: sheet_headers[1].col }
           )

--- a/spec/sheetah/messaging/messages/duplicated_header_spec.rb
+++ b/spec/sheetah/messaging/messages/duplicated_header_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Sheetah::Messaging::Messages::DuplicatedHeader do
     let(:message) do
       described_class.new(
         code: "duplicated_header",
-        code_data: "header_foo",
+        code_data: { value: "header_foo" },
         scope: "COL",
         scope_data: { col: "FOO" }
       )

--- a/spec/sheetah/messaging/messages/invalid_header_spec.rb
+++ b/spec/sheetah/messaging/messages/invalid_header_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Sheetah::Messaging::Messages::InvalidHeader do
     let(:message) do
       described_class.new(
         code: "invalid_header",
-        code_data: "header_foo",
+        code_data: { value: "header_foo" },
         scope: "COL",
         scope_data: { col: "FOO" }
       )

--- a/spec/sheetah/messaging/messages/missing_column_spec.rb
+++ b/spec/sheetah/messaging/messages/missing_column_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Sheetah::Messaging::Messages::MissingColumn do
     let(:message) do
       described_class.new(
         code: "missing_column",
-        code_data: "header_foo",
+        code_data: { value: "header_foo" },
         scope: "SHEET",
         scope_data: nil
       )

--- a/spec/sheetah_spec.rb
+++ b/spec/sheetah_spec.rb
@@ -152,14 +152,14 @@ RSpec.describe Sheetah, monadic_result: true do
           messages: contain_exactly(
             have_attributes(
               code: "invalid_header",
-              code_data: "oof",
+              code_data: { value: "oof" },
               scope: Sheetah::Messaging::SCOPES::COL,
               scope_data: { col: "C" },
               severity: Sheetah::Messaging::SEVERITIES::ERROR
             ),
             have_attributes(
               code: "invalid_header",
-              code_data: "rab",
+              code_data: { value: "rab" },
               scope: Sheetah::Messaging::SCOPES::COL,
               scope_data: { col: "F" },
               severity: Sheetah::Messaging::SEVERITIES::ERROR
@@ -188,14 +188,14 @@ RSpec.describe Sheetah, monadic_result: true do
         messages: contain_exactly(
           have_attributes(
             code: "missing_column",
-            code_data: "Foo",
+            code_data: { value: "Foo" },
             scope: Sheetah::Messaging::SCOPES::SHEET,
             scope_data: nil,
             severity: Sheetah::Messaging::SEVERITIES::ERROR
           ),
           have_attributes(
             code: "missing_column",
-            code_data: "Bar 5",
+            code_data: { value: "Bar 5" },
             scope: Sheetah::Messaging::SCOPES::SHEET,
             scope_data: nil,
             severity: Sheetah::Messaging::SEVERITIES::ERROR


### PR DESCRIPTION
In order to simplify usage, documentation and evolution, message `code_data` should all be backed by the same composite data structure, i.e. a `Hash`. That said, `code_data` still can be nil.