### PR TITLE
Simplify Specification

### DIFF
--- a/lib/sheetah/column.rb
+++ b/lib/sheetah/column.rb
@@ -7,20 +7,22 @@ module Sheetah
       type:,
       index:,
       header:,
-      header_pattern: nil,
-      required: false
+      header_pattern:,
+      required:
     )
       @key            = key
       @type           = type
       @index          = index
       @header         = header
-      @header_pattern = (header_pattern || header.dup).freeze
+      @header_pattern = header_pattern
       @required       = required
-
-      freeze
     end
 
-    attr_reader :key, :type, :index, :header, :header_pattern
+    attr_reader :key,
+                :type,
+                :index,
+                :header,
+                :header_pattern
 
     def required?
       @required

--- a/lib/sheetah/specification.rb
+++ b/lib/sheetah/specification.rb
@@ -1,64 +1,30 @@
 # frozen_string_literal: true
 
-require_relative "errors/spec_error"
-
 module Sheetah
   class Specification
-    class InvalidPatternError < Errors::SpecError
-    end
-
-    class MutablePatternError < Errors::SpecError
-    end
-
-    class DuplicatedPatternError < Errors::SpecError
-    end
-
-    def initialize(ignore_unspecified_columns: false)
-      @column_by_pattern = {}
+    def initialize(columns:, ignore_unspecified_columns: false)
+      @columns = columns
       @ignore_unspecified_columns = ignore_unspecified_columns
-    end
-
-    def set(pattern, column)
-      if pattern.nil?
-        raise InvalidPatternError, pattern.inspect
-      end
-
-      unless pattern.frozen?
-        raise MutablePatternError, pattern.inspect
-      end
-
-      if @column_by_pattern.key?(pattern)
-        raise DuplicatedPatternError, pattern.inspect
-      end
-
-      @column_by_pattern[pattern] = column
     end
 
     def get(header)
       return if header.nil?
 
-      @column_by_pattern.each do |pattern, column|
-        return column if pattern === header # rubocop:disable Style/CaseEquality
+      @columns.find do |column|
+        column.header_pattern === header # rubocop:disable Style/CaseEquality
       end
-
-      nil
     end
 
     def required_columns
-      @column_by_pattern.each_value.select(&:required?)
+      @columns.select(&:required?)
     end
 
     def optional_columns
-      @column_by_pattern.each_value.reject(&:required?)
+      @columns.reject(&:required?)
     end
 
     def ignore_unspecified_columns?
       @ignore_unspecified_columns
-    end
-
-    def freeze
-      @column_by_pattern.freeze
-      super
     end
   end
 end

--- a/lib/sheetah/specification.rb
+++ b/lib/sheetah/specification.rb
@@ -11,7 +11,7 @@ module Sheetah
       return if header.nil?
 
       @columns.find do |column|
-        column.header_pattern === header # rubocop:disable Style/CaseEquality
+        column.header_pattern.match?(header)
       end
     end
 

--- a/lib/sheetah/template.rb
+++ b/lib/sheetah/template.rb
@@ -32,13 +32,18 @@ module Sheetah
     end
 
     def apply(config)
-      specification = Specification.new(ignore_unspecified_columns: @ignore_unspecified_columns)
+      columns = []
 
       @attributes.each do |attribute|
         attribute.each_column(config) do |column|
-          specification.set(column.header_pattern, column)
+          columns << column
         end
       end
+
+      specification = Specification.new(
+        columns: columns.freeze,
+        ignore_unspecified_columns: @ignore_unspecified_columns
+      )
 
       specification.freeze
     end

--- a/lib/sheetah/template_config.rb
+++ b/lib/sheetah/template_config.rb
@@ -10,6 +10,19 @@ module Sheetah
 
     attr_reader :types
 
+    # Given an attribute key and a possibily-nil column index, return the header and header pattern
+    # for that column.
+    #
+    # The return value should be an array with two items:
+    #
+    # 1. The first item is the header, as a String.
+    # 2. The second item is the header pattern, and should respond to `#match?` with a boolean
+    #     value. Instances of Regexp will obviously do, but the requirement is really about the
+    #     `#match?` method.
+    #
+    # @param key [Symbol, String]
+    # @param index [Integer, nil]
+    # @return [Array(String, #match?)]
     def header(key, index)
       header = key.to_s.capitalize
       header = "#{header} #{index + 1}" if index

--- a/spec/sheetah/column_spec.rb
+++ b/spec/sheetah/column_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Sheetah::Column do
   let(:index) { double }
   let(:header) { double }
   let(:header_pattern) { Object.new }
+  let(:required) { false }
 
   let(:col) do
     described_class.new(
@@ -15,12 +16,9 @@ RSpec.describe Sheetah::Column do
       type: type,
       index: index,
       header: header,
-      header_pattern: header_pattern
+      header_pattern: header_pattern,
+      required: required
     )
-  end
-
-  it "is frozen" do
-    expect(col).to be_frozen
   end
 
   describe "#key" do
@@ -48,31 +46,14 @@ RSpec.describe Sheetah::Column do
   end
 
   describe "#header_pattern" do
-    it "reads a frozen attribute" do
+    it "reads the attribute" do
       expect(col.header_pattern).to be(header_pattern)
-      expect(col.header_pattern).to be_frozen
     end
+  end
 
-    context "when the value is not given" do
-      let(:header_copy) { Object.new }
-
-      let(:col) do
-        described_class.new(
-          key: key,
-          type: type,
-          index: index,
-          header: header
-        )
-      end
-
-      before do
-        allow(header).to receive(:dup).and_return(header_copy)
-      end
-
-      it "defaults to a frozen copy of the header value" do
-        expect(col.header).not_to be_frozen
-        expect(col.header_pattern).to be(header_copy) & be_frozen
-      end
+  describe "#required?" do
+    it "reads the attribute" do
+      expect(col.required?).to be(required)
     end
   end
 end


### PR DESCRIPTION
What's expected from a `Specification` is simple and yet the implementation is complex. This pull request intends to reduce the complexity of that part of the codebase by keeping only what's necessary.

