### PR TITLE
Consistent freezing

### DIFF
--- a/lib/sheetah/attribute.rb
+++ b/lib/sheetah/attribute.rb
@@ -16,8 +16,6 @@ module Sheetah
         else
           ScalarType.new(type)
         end
-
-      freeze
     end
 
     attr_reader :key, :type
@@ -41,6 +39,11 @@ module Sheetah
       end
     end
 
+    def freeze
+      type.freeze
+      super
+    end
+
     class Scalar
       def initialize(name)
         @required = name.end_with?("!")
@@ -53,7 +56,6 @@ module Sheetah
     class ScalarType
       def initialize(scalar)
         @scalar = Scalar.new(scalar)
-        freeze
       end
 
       def compile(container)
@@ -67,13 +69,17 @@ module Sheetah
 
         self
       end
+
+      def freeze
+        @scalar.freeze
+        super
+      end
     end
 
     class CompositeType
       def initialize(composite:, scalars:)
         @composite = composite
-        @scalars = scalars.map { |scalar| Scalar.new(scalar) }.freeze
-        freeze
+        @scalars = scalars.map { |scalar| Scalar.new(scalar) }
       end
 
       def compile(container)
@@ -88,6 +94,12 @@ module Sheetah
         end
 
         self
+      end
+
+      def freeze
+        @scalars.freeze
+        @scalars.each(&:freeze)
+        super
       end
     end
 

--- a/lib/sheetah/template.rb
+++ b/lib/sheetah/template.rb
@@ -48,12 +48,18 @@ module Sheetah
       specification.freeze
     end
 
+    def freeze
+      @attributes.freeze
+      @attributes.each(&:freeze)
+      super
+    end
+
     private
 
     def build_attributes(attributes)
       uniq_keys = Set.new
 
-      uniq_attributes = attributes.map do |kwargs|
+      attributes.map do |kwargs|
         attribute = Attribute.new(**kwargs)
 
         unless uniq_keys.add?(attribute.key)
@@ -62,8 +68,6 @@ module Sheetah
 
         attribute
       end
-
-      uniq_attributes.freeze
     end
   end
 end

--- a/lib/sheetah/template.rb
+++ b/lib/sheetah/template.rb
@@ -36,7 +36,7 @@ module Sheetah
 
       @attributes.each do |attribute|
         attribute.each_column(config) do |column|
-          columns << column
+          columns << column.freeze
         end
       end
 

--- a/spec/sheetah_spec.rb
+++ b/spec/sheetah_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Sheetah, monadic_result: true do
   end
 
   let(:template) do
-    Sheetah::Template.new(**template_opts)
+    Sheetah::Template.new(**template_opts).freeze
   end
 
   let(:template_config) do


### PR DESCRIPTION
It is not always convenient to only be able to produce frozen instances of a class. For example, it is impossible to stub/mock methods with RSpec on a frozen object, which can make the task of writing complete specs more difficult. So we prefer to initialize mutable objects, and explicitly freezing them afterwards when necessary.

This PR applies that reasoning to templates and their dependencies.

Templates are meant to live as shared objects in an application, so that different configs may be applied concurrently to the same template instance to produce as many specifications. Because they are concurrently shared, templates should be considered immutable and freezing them is a good practice.

When it comes to freezing objects, there are different ways to look at them and their internal state:

- The object does not have any internal state, or that state is already frozen (i.e. it composed of booleans, symbols, etc.). Then it is enough to only freeze the object itself with its default `#freeze` method.
- The object has some mutable internal state. Two possibilities:
  - It is the one that initialized the state, and thus is responsible for it (it "owns" that state).
  - It was passed that state from the outside, and thus is not responsible for it (it doesn't "own" it).

When a object has and owns some mutable state, then that state should be frozen when the object itself is frozen.

When a object has but doesn't own some mutable state, then that state should not be frozen when the object itself is frozen.

This PR enforces those rules as far as `Template` and its related classes (`Attribute`, etc.) are concerned.