### PR TITLE
Values of attributes are now required by default

### DIFF
--- a/lib/sheetah/attribute_types/value.rb
+++ b/lib/sheetah/attribute_types/value.rb
@@ -29,10 +29,11 @@ module Sheetah
 
       def self.from_type_name(type)
         type = type.to_s
-        required = type.end_with?("!")
-        type = (required ? type.slice(0..-2) : type).to_sym
 
-        new(type: type, required: required)
+        optional = type.end_with?("?")
+        type = (optional ? type.slice(0..-2) : type).to_sym
+
+        new(type: type, required: !optional)
       end
 
       private_class_method :from_type_name
@@ -40,7 +41,7 @@ module Sheetah
       # @param type [Symbol] The name used to refer to a scalar type from a {Types::Container}.
       # @param required [Boolean] Is the value required to be given in the input ?
       # @see .build
-      def initialize(type:, required: false)
+      def initialize(type:, required: true)
         @type = type
         @required = required
       end

--- a/spec/sheetah/attribute_types/value_spec.rb
+++ b/spec/sheetah/attribute_types/value_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe Sheetah::AttributeTypes::Value do
     end
 
     context "when the type requirement is implicit" do
-      it "has an optional type" do
+      it "has a required type" do
         value = buildval(type: type)
-        expect(value).to eq(newval(type: type, required: false))
+        expect(value).to eq(newval(type: type, required: true))
       end
 
       it "can be expressed with syntactic sugar" do
         value = buildval(type)
-        expect(value).to eq(newval(type: type, required: false))
+        expect(value).to eq(newval(type: type, required: true))
       end
     end
 
@@ -44,9 +44,9 @@ RSpec.describe Sheetah::AttributeTypes::Value do
         expect(value).to eq(newval(type: type, required: true))
       end
 
-      it "can be required using syntactic sugar" do
-        value = buildval(:"#{type}!")
-        expect(value).to eq(newval(type: type, required: true))
+      it "can be optional using syntactic sugar" do
+        value = buildval(:"#{type}?")
+        expect(value).to eq(newval(type: type, required: false))
       end
     end
   end

--- a/spec/sheetah/attribute_types_spec.rb
+++ b/spec/sheetah/attribute_types_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe Sheetah::AttributeTypes do
     let(:type) do
       {
         type: :foo,
-        required: true,
+        required: false,
       }
     end
 
     it "has the expected type" do
-      expect(build(type)).to eq(scalar(value(type: :foo, required: true)))
+      expect(build(type)).to eq(scalar(value(type: :foo, required: false)))
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Sheetah::AttributeTypes do
     end
 
     it "has the expected type" do
-      expect(build(type)).to eq(scalar(value(type: :foo, required: false)))
+      expect(build(type)).to eq(scalar(value(type: :foo, required: true)))
     end
   end
 
@@ -48,8 +48,8 @@ RSpec.describe Sheetah::AttributeTypes do
         composite: :oof,
         scalars: [
           :foo,
-          :bar!,
-          { type: :baz, required: true },
+          :bar?,
+          { type: :baz, required: false },
         ],
       }
     end
@@ -59,9 +59,9 @@ RSpec.describe Sheetah::AttributeTypes do
         composite(
           composite: :oof,
           scalars: [
-            value(type: :foo, required: false),
-            value(type: :bar, required: true),
-            value(type: :baz, required: true),
+            value(type: :foo, required: true),
+            value(type: :bar, required: false),
+            value(type: :baz, required: false),
           ]
         )
       )
@@ -72,8 +72,8 @@ RSpec.describe Sheetah::AttributeTypes do
     let(:type) do
       [
         :foo,
-        :bar!,
-        { type: :baz, required: true },
+        :bar?,
+        { type: :baz, required: false },
       ]
     end
 
@@ -82,9 +82,9 @@ RSpec.describe Sheetah::AttributeTypes do
         composite(
           composite: :array,
           scalars: [
-            value(type: :foo, required: false),
-            value(type: :bar, required: true),
-            value(type: :baz, required: true),
+            value(type: :foo, required: true),
+            value(type: :bar, required: false),
+            value(type: :baz, required: false),
           ]
         )
       )

--- a/spec/sheetah_spec.rb
+++ b/spec/sheetah_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe Sheetah, monadic_result: true do
       attributes: [
         {
           key: :foo,
-          type: :reverse_string!,
+          type: :reverse_string,
         },
         {
           key: "bar",
           type: {
             composite: :array,
             scalars: %i[
-              string
+              string?
+              scalar?
+              email?
+              scalar?
               scalar
-              email
-              scalar
-              scalar!
             ],
           },
         },


### PR DESCRIPTION
If an attribute is defined, then it seems more likely that the value for it appears in the tabular document, rather than be missing.

In other words, templates are now a bit more strict, but you still can use optional columns if need be.