### PR TITLE
Expose consistent indices for rows/cols

### DIFF
--- a/lib/sheetah/backends/csv.rb
+++ b/lib/sheetah/backends/csv.rb
@@ -57,7 +57,7 @@ module Sheetah
         return to_enum(:each_row) unless block_given?
 
         handle_malformed_csv do
-          @csv.each.with_index(1) do |raw, row|
+          @csv.each.with_index(2) do |raw, row|
             value = Array.new(@cols_count) do |col_idx|
               col = Sheet.int2col(col_idx + 1)
 

--- a/lib/sheetah/backends/wrapper.rb
+++ b/lib/sheetah/backends/wrapper.rb
@@ -60,7 +60,7 @@ module Sheetah
         @headers = table[headers_row]
 
         @first_row = headers_row.succ
-        @first_row_name = 1
+        @first_row_name = 2
         @rows_count = table_size - @first_row
 
         @first_col = 0

--- a/lib/sheetah/backends/xlsx.rb
+++ b/lib/sheetah/backends/xlsx.rb
@@ -114,7 +114,7 @@ module Sheetah
           offset = first_row - 1
 
           @first_row = first_row
-          @first_name = 1
+          @first_name = first_row
           @count = last_row - offset
         end
       end
@@ -124,7 +124,7 @@ module Sheetah
           cols_offset = first_col - 1
 
           @first_col = first_col
-          @first_name = 1
+          @first_name = first_col
           @count = last_col - cols_offset
         end
 

--- a/spec/sheetah/backends/xlsx_spec.rb
+++ b/spec/sheetah/backends/xlsx_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
     end
 
     it "ignores the empty final rows when detecting the rows" do
-      rows = build_rows(source_data[1..])
+      rows = build_rows(source_data[1..], row: 3)
       expect { |b| sheet.each_row(&b) }.to yield_successive_args(*rows)
     end
   end
@@ -128,12 +128,12 @@ RSpec.describe Sheetah::Backends::Xlsx do
     end
 
     it "ignores the initial empty columns when detecting the headers" do
-      headers = build_headers(source_data[0])
+      headers = build_headers(source_data[0], col: "B")
       expect { |b| sheet.each_header(&b) }.to yield_successive_args(*headers)
     end
 
     it "ignores the initial empty columns when detecting the rows" do
-      rows = build_rows(source_data[1..])
+      rows = build_rows(source_data[1..], col: "B")
       expect { |b| sheet.each_row(&b) }.to yield_successive_args(*rows)
     end
   end

--- a/spec/sheetah_spec.rb
+++ b/spec/sheetah_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Sheetah, monadic_result: true do
           code: "must_be_email",
           code_data: { value: "boudiou !".inspect },
           scope: Sheetah::Messaging::SCOPES::CELL,
-          scope_data: { row: 3, col: "B" },
+          scope_data: { row: 4, col: "B" },
           severity: Sheetah::Messaging::SEVERITIES::ERROR
         )
       )

--- a/spec/support/shared/sheet/factories.rb
+++ b/spec/support/shared/sheet/factories.rb
@@ -31,7 +31,7 @@ RSpec.shared_context "sheet/factories" do
     end
   end
 
-  def build_rows(list_of_values, row: 1, col: "A")
+  def build_rows(list_of_values, row: 2, col: "A")
     list_of_values.map.with_index(row) do |values, row_index|
       value = build_cells(values, row: row_index, col: col)
 


### PR DESCRIPTION
Any (non-header) row is supposed to be identified by an integer-based index, and any column by a letter-based one. Indices would always start at 1 or A (respectively), even if the actual tabular document could use other coordinates for the actual cells.

This commit changes this behavior.

A backend is now required to expose its rows/cols/cells with indices that are consistent with the actual indices of the underlying document. In other words, if a cell is located at B4 in XLSX spreadsheet editors, then it must be exposed with (row: 4, col: B) by the XLSX backend.

NOTE: As far as indices are concerned, header rows and data rows are handled differently: a header row doesn't have a "row" index, because it is not considered a row, per se. Only data rows have indices. Now that rows reflect their actual indices, this behavior may seem confusing, and might change in a latter commit.