### PR TITLE
Input values for backends can't be nil

### DIFF
--- a/lib/sheetah/backends/wrapper.rb
+++ b/lib/sheetah/backends/wrapper.rb
@@ -8,8 +8,6 @@ module Sheetah
       include Sheet
 
       def initialize(table)
-        raise Error if table.nil?
-
         if (table_size = table.size).positive?
           init_with_filled_table(table, table_size: table_size)
         else

--- a/lib/sheetah/backends/xlsx.rb
+++ b/lib/sheetah/backends/xlsx.rb
@@ -13,8 +13,6 @@ module Sheetah
       include Sheet
 
       def initialize(path)
-        raise Error if path.nil?
-
         @roo = Roo::Excelx.new(path)
 
         worksheet = @roo.sheet_for(@roo.default_sheet)

--- a/spec/sheetah/backends/wrapper_spec.rb
+++ b/spec/sheetah/backends/wrapper_spec.rb
@@ -69,12 +69,6 @@ RSpec.describe Sheetah::Backends::Wrapper do
     sheet.close unless example.metadata[:autoclose_sheet] == false
   end
 
-  context "when the input table is nil" do
-    it "raises an error", autoclose_sheet: false do
-      expect { described_class.new(nil) }.to raise_error(Sheetah::Sheet::Error)
-    end
-  end
-
   context "when the input table is empty" do
     let(:source) do
       []

--- a/spec/sheetah/backends/xlsx_spec.rb
+++ b/spec/sheetah/backends/xlsx_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe Sheetah::Backends::Xlsx do
     sheet.close unless example.metadata[:autoclose_sheet] == false
   end
 
-  context "when the input table is nil" do
-    it "raises an error", autoclose_sheet: false do
-      expect { described_class.new(nil) }.to raise_error(Sheetah::Sheet::Error)
-    end
-  end
-
   context "when the input table is empty" do
     let(:source) do
       "xlsx/empty.xlsx"


### PR DESCRIPTION
It makes no sense to pass `nil` as the primary argument to a backend at initialization, whatever the backend may be. We could provide an API to handle that error explicitly for the benefit of the users of the backend.

On the other end, passing `nil` as the primary argument is such an obvious mistake that we prefer to consider it won't happen and that the burden of ensuring that invariant belongs to the user of the backend, rather than its implementer.

Should the need for a dedicated API about `nil` inputs arise, we would then consider it again.