### PR TITLE
Closing a backend is final

### DIFF
--- a/lib/sheetah/backends/csv.rb
+++ b/lib/sheetah/backends/csv.rb
@@ -51,6 +51,8 @@ module Sheetah
       end
 
       def each_header
+        raise_if_closed
+
         return to_enum(:each_header) { @cols_count } unless block_given?
 
         @headers.each_with_index do |header, col_idx|
@@ -63,6 +65,8 @@ module Sheetah
       end
 
       def each_row
+        raise_if_closed
+
         return to_enum(:each_row) unless block_given?
 
         handle_malformed_csv do
@@ -80,10 +84,8 @@ module Sheetah
         self
       end
 
-      def close
-        # Do nothing: this backend isn't responsible for opening the IO, and therefore it is not
-        # responsible for closing it either.
-      end
+      # The backend isn't responsible for opening the IO, and therefore it is not responsible for
+      # closing it either.
 
       private
 

--- a/lib/sheetah/backends/wrapper.rb
+++ b/lib/sheetah/backends/wrapper.rb
@@ -18,6 +18,8 @@ module Sheetah
       end
 
       def each_header
+        raise_if_closed
+
         return to_enum(:each_header) { @cols_count } unless block_given?
 
         @cols_count.times do |col_index|
@@ -30,6 +32,8 @@ module Sheetah
       end
 
       def each_row
+        raise_if_closed
+
         return to_enum(:each_row) unless block_given?
 
         @rows_count.times do |row_index|
@@ -45,10 +49,6 @@ module Sheetah
         end
 
         self
-      end
-
-      def close
-        # nothing to do here
       end
 
       private

--- a/lib/sheetah/backends/xlsx.rb
+++ b/lib/sheetah/backends/xlsx.rb
@@ -27,6 +27,8 @@ module Sheetah
       end
 
       def each_header
+        raise_if_closed
+
         return to_enum(:each_header) { @cols_count } unless block_given?
 
         @cols_count.times do |col_index|
@@ -42,6 +44,8 @@ module Sheetah
       end
 
       def each_row
+        raise_if_closed
+
         return to_enum(:each_row) unless block_given?
 
         @rows_count.times do |row_index|
@@ -63,9 +67,9 @@ module Sheetah
       end
 
       def close
-        @roo.close
-
-        nil
+        super do
+          @roo.close
+        end
       end
 
       private

--- a/lib/sheetah/sheet.rb
+++ b/lib/sheetah/sheet.rb
@@ -38,6 +38,9 @@ module Sheetah
     class Error < Errors::Error
     end
 
+    class ClosureError < Error
+    end
+
     class InputError < Error
     end
 
@@ -89,6 +92,7 @@ module Sheetah
 
     def initialize(messenger: Messaging::Messenger.new)
       @messenger = messenger
+      @closed = false
     end
 
     attr_reader :messenger
@@ -102,7 +106,25 @@ module Sheetah
     end
 
     def close
-      raise NoMethodError, "You must implement #{self.class}#close => nil"
+      return if closed?
+
+      yield if block_given?
+
+      instance_variables.each { |ivar| remove_instance_variable(ivar) }
+
+      @closed = true
+
+      nil
+    end
+
+    def closed?
+      @closed == true
+    end
+
+    private
+
+    def raise_if_closed
+      raise ClosureError if closed?
     end
   end
 end

--- a/spec/sheetah/sheet_spec.rb
+++ b/spec/sheetah/sheet_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Sheetah::Sheet, monadic_result: true do
     end
   end
 
+  describe "::ClosureError" do
+    subject { sheet_class::ClosureError }
+
+    it "exposes some kind of Sheetah::Sheet::Error" do
+      expect(subject.superclass).to be(Sheetah::Sheet::Error)
+    end
+  end
+
   describe "::InputError" do
     subject { sheet_class::InputError }
 
@@ -281,10 +289,21 @@ RSpec.describe Sheetah::Sheet, monadic_result: true do
   end
 
   describe "#close" do
-    it "is abstract" do
-      expect { sheet.close }.to raise_error(
-        NoMethodError, "You must implement SheetClass#close => nil"
-      )
+    before { sheet }
+
+    it "removes the instance variables" do
+      expect { sheet.close }.to [
+        change { sheet.instance_variable_defined?(:@foo) }.from(true).to(false),
+        change { sheet.instance_variable_defined?(:@bar) }.from(true).to(false),
+      ].reduce(:&)
+    end
+
+    it "marks the instance as closed" do
+      expect { sheet.close }.to change(sheet, :closed?).from(false).to(true)
+    end
+
+    it "returns nil" do
+      expect(sheet.close).to be_nil
     end
   end
 end

--- a/spec/support/shared/sheet/backend_empty.rb
+++ b/spec/support/shared/sheet/backend_empty.rb
@@ -52,4 +52,16 @@ RSpec.shared_examples "sheet/backend_empty" do
       expect(sheet.close).to be_nil
     end
   end
+
+  context "when it is closed" do
+    before { sheet.close }
+
+    it "can't enumerate headers" do
+      expect { sheet.each_header }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+
+    it "can't enumerate rows" do
+      expect { sheet.each_row }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+  end
 end

--- a/spec/support/shared/sheet/backend_filled.rb
+++ b/spec/support/shared/sheet/backend_filled.rb
@@ -64,4 +64,16 @@ RSpec.shared_examples "sheet/backend_filled" do
       expect(sheet.close).to be_nil
     end
   end
+
+  context "when it is closed" do
+    before { sheet.close }
+
+    it "can't enumerate headers" do
+      expect { sheet.each_header }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+
+    it "can't enumerate rows" do
+      expect { sheet.each_row }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+  end
 end


### PR DESCRIPTION
Once closed, a backend is only an empty, unusable object, only good for garbage collection.

The implementers of a backend should therefore make sure to free any resources under the direct responsibility of the backend while closing.