### PR TITLE
Accept custom headers in backends 

### DIFF
--- a/lib/sheetah/backends/wrapper.rb
+++ b/lib/sheetah/backends/wrapper.rb
@@ -7,13 +7,13 @@ module Sheetah
     class Wrapper
       include Sheet
 
-      def initialize(table, **opts)
+      def initialize(table, headers: nil, **opts)
         super(**opts)
 
         if (table_size = table.size).positive?
-          init_with_filled_table(table, table_size: table_size)
+          init_with_filled_table(table, table_size: table_size, headers: headers)
         else
-          init_with_empty_table
+          init_with_empty_table(headers: headers)
         end
       end
 
@@ -53,24 +53,39 @@ module Sheetah
 
       private
 
-      def init_with_filled_table(table, table_size:)
+      def init_with_filled_table(table, table_size:, headers:)
         @table = table
 
-        headers_row = 0
-        @headers = table[headers_row]
+        if headers
+          ensure_compatible_size(table[0].size, headers.size)
+
+          headers_row = -1
+          @headers = headers
+        else
+          headers_row = 0
+          @headers = table[headers_row]
+        end
 
         @first_row = headers_row.succ
-        @first_row_name = 2
+        @first_row_name = @first_row.succ
         @rows_count = table_size - @first_row
 
         @first_col = 0
-        @first_col_name = 1
+        @first_col_name = @first_col.succ
         @cols_count = @headers.size
       end
 
-      def init_with_empty_table
+      def init_with_empty_table(headers:)
         @rows_count = 0
-        @cols_count = 0
+
+        if headers
+          @headers = headers
+          @first_col = 0
+          @first_col_name = @first_col.succ
+          @cols_count = headers.size
+        else
+          @cols_count = 0
+        end
       end
 
       def read_row(row_index)

--- a/lib/sheetah/backends/xlsx.rb
+++ b/lib/sheetah/backends/xlsx.rb
@@ -12,7 +12,7 @@ module Sheetah
     class Xlsx
       include Sheet
 
-      def initialize(path, **opts)
+      def initialize(path, headers: nil, **opts)
         super(**opts)
 
         @roo = Roo::Excelx.new(path)
@@ -20,24 +20,22 @@ module Sheetah
         worksheet = @roo.sheet_for(@roo.default_sheet)
 
         if worksheet.first_row
-          init_with_filled_table(worksheet)
+          init_with_filled_table(worksheet, headers: headers)
         else
-          init_with_empty_table
+          init_with_empty_table(headers: headers)
         end
       end
 
-      def each_header
+      def each_header(&block)
         raise_if_closed
 
-        return to_enum(:each_header) { @cols_count } unless block_given?
+        return to_enum(:each_header) { @cols_count } unless block
+        return self if @cols_count.zero?
 
-        @cols_count.times do |col_index|
-          col = @cols.name(col_index)
-
-          cell_coords = [@rows.headers_coord, @cols.coord(col_index)]
-          cell_value = @cells[cell_coords]&.value
-
-          yield Header.new(col: col, value: cell_value)
+        if @headers
+          each_custom_header(&block)
+        else
+          each_cell_header(&block)
         end
 
         self
@@ -74,10 +72,11 @@ module Sheetah
 
       private
 
-      def init_with_filled_table(worksheet)
+      def init_with_filled_table(worksheet, headers:)
         @rows = Rows.new(
           first_row: worksheet.first_row,
-          last_row: worksheet.last_row
+          last_row: worksheet.last_row,
+          include_headers: headers.nil?
         )
 
         @cols = Cols.new(
@@ -88,18 +87,57 @@ module Sheetah
         @rows_count = @rows.count
         @cols_count = @cols.count
 
+        if (@headers = headers)
+          ensure_compatible_size(@cols_count, @headers.size)
+        end
+
         @cells = worksheet.cells
       end
 
-      def init_with_empty_table
+      def init_with_empty_table(headers:)
+        @rows = nil
         @rows_count = 0
-        @cols_count = 0
+
+        if headers
+          @cols = Cols.new(first_col: 1, last_col: headers.size)
+          @cols_count = @cols.count
+        else
+          @cols = nil
+          @cols_count = 0
+        end
+
+        @headers = headers
+        @cells = nil
+      end
+
+      def each_custom_header
+        @headers.each_with_index do |value, col_index|
+          col = @cols.name(col_index)
+
+          yield Header.new(col: col, value: value)
+        end
+      end
+
+      def each_cell_header
+        @cols_count.times do |col_index|
+          col = @cols.name(col_index)
+
+          cell_coords = [@rows.headers_coord, @cols.coord(col_index)]
+          cell_value = @cells[cell_coords]&.value
+
+          yield Header.new(col: col, value: cell_value)
+        end
       end
 
       class Rows
-        def initialize(first_row:, last_row:)
-          @headers_coord = first_row
-          init(first_row.succ, last_row)
+        def initialize(first_row:, last_row:, include_headers:)
+          if include_headers
+            @headers_coord = first_row
+            init(first_row.succ, last_row)
+          else
+            @headers_coord = nil
+            init(first_row, last_row)
+          end
         end
 
         attr_reader :count, :headers_coord

--- a/lib/sheetah/sheet.rb
+++ b/lib/sheetah/sheet.rb
@@ -41,6 +41,12 @@ module Sheetah
     class ClosureError < Error
     end
 
+    class TooFewHeaders < Error
+    end
+
+    class TooManyHeaders < Error
+    end
+
     class InputError < Error
     end
 
@@ -125,6 +131,15 @@ module Sheetah
 
     def raise_if_closed
       raise ClosureError if closed?
+    end
+
+    def ensure_compatible_size(row_size, headers_size)
+      case row_size <=> headers_size
+      when -1
+        raise TooManyHeaders, "Expected #{row_size} headers, got: #{headers_size}"
+      when 1
+        raise TooFewHeaders, "Expected #{row_size} headers, got: #{headers_size}"
+      end
     end
   end
 end

--- a/spec/sheetah/backends/csv_spec.rb
+++ b/spec/sheetah/backends/csv_spec.rb
@@ -42,15 +42,7 @@ RSpec.describe Sheetah::Backends::Csv do
       []
     end
 
-    include_examples "sheet/backend_empty", pending_custom_headers: true
-  end
-
-  context "when the input table headers are empty" do
-    let(:source) do
-      [[]]
-    end
-
-    include_examples "sheet/backend_empty", pending_custom_headers: true
+    include_examples "sheet/backend_empty"
   end
 
   context "when the input table is filled" do
@@ -62,7 +54,7 @@ RSpec.describe Sheetah::Backends::Csv do
       end.freeze
     end
 
-    include_examples "sheet/backend_filled", pending_custom_headers: true
+    include_examples "sheet/backend_filled"
   end
 
   describe "encodings" do

--- a/spec/sheetah/backends/csv_spec.rb
+++ b/spec/sheetah/backends/csv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Sheetah::Backends::Csv do
       []
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", pending_custom_headers: true
   end
 
   context "when the input table headers are empty" do
@@ -50,7 +50,7 @@ RSpec.describe Sheetah::Backends::Csv do
       [[]]
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", pending_custom_headers: true
   end
 
   context "when the input table is filled" do
@@ -62,7 +62,7 @@ RSpec.describe Sheetah::Backends::Csv do
       end.freeze
     end
 
-    include_examples "sheet/backend_filled"
+    include_examples "sheet/backend_filled", pending_custom_headers: true
   end
 
   describe "encodings" do

--- a/spec/sheetah/backends/wrapper_spec.rb
+++ b/spec/sheetah/backends/wrapper_spec.rb
@@ -74,15 +74,7 @@ RSpec.describe Sheetah::Backends::Wrapper do
       []
     end
 
-    include_examples "sheet/backend_empty", pending_custom_headers: true
-  end
-
-  context "when the input table headers are empty" do
-    let(:source) do
-      [[]]
-    end
-
-    include_examples "sheet/backend_empty", pending_custom_headers: true
+    include_examples "sheet/backend_empty"
   end
 
   context "when the input table is filled" do
@@ -94,6 +86,6 @@ RSpec.describe Sheetah::Backends::Wrapper do
       end.freeze
     end
 
-    include_examples "sheet/backend_filled", pending_custom_headers: true
+    include_examples "sheet/backend_filled"
   end
 end

--- a/spec/sheetah/backends/wrapper_spec.rb
+++ b/spec/sheetah/backends/wrapper_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Sheetah::Backends::Wrapper do
       []
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", pending_custom_headers: true
   end
 
   context "when the input table headers are empty" do
@@ -82,7 +82,7 @@ RSpec.describe Sheetah::Backends::Wrapper do
       [[]]
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", pending_custom_headers: true
   end
 
   context "when the input table is filled" do
@@ -94,6 +94,6 @@ RSpec.describe Sheetah::Backends::Wrapper do
       end.freeze
     end
 
-    include_examples "sheet/backend_filled"
+    include_examples "sheet/backend_filled", pending_custom_headers: true
   end
 end

--- a/spec/sheetah/backends/xlsx_spec.rb
+++ b/spec/sheetah/backends/xlsx_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       []
     end
 
-    include_examples "sheet/backend_empty", pending_custom_headers: true
+    include_examples "sheet/backend_empty"
   end
 
   context "when the input table is filled" do
@@ -53,7 +53,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       ]
     end
 
-    include_examples "sheet/backend_filled", pending_custom_headers: true
+    include_examples "sheet/backend_filled"
   end
 
   context "when the input table includes empty rows around the content" do

--- a/spec/sheetah/backends/xlsx_spec.rb
+++ b/spec/sheetah/backends/xlsx_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       []
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", pending_custom_headers: true
   end
 
   context "when the input table is filled" do
@@ -53,7 +53,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       ]
     end
 
-    include_examples "sheet/backend_filled"
+    include_examples "sheet/backend_filled", pending_custom_headers: true
   end
 
   context "when the input table includes empty rows around the content" do

--- a/spec/support/shared/sheet/backend_empty.rb
+++ b/spec/support/shared/sheet/backend_empty.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_empty" do
+RSpec.shared_examples "sheet/backend_empty" do |pending_custom_headers: false|
   describe "#each_header" do
     context "with a block" do
       it "doesn't yield" do
@@ -62,6 +62,21 @@ RSpec.shared_examples "sheet/backend_empty" do
 
     it "can't enumerate rows" do
       expect { sheet.each_row }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+  end
+
+  context "when headers are customized", pending: pending_custom_headers do
+    let(:headers_data) do
+      %w[foo bar baz]
+    end
+
+    let(:sheet_opts) do
+      super().merge(headers: headers_data)
+    end
+
+    it "relies on the custom headers" do
+      headers = build_headers(headers_data)
+      expect { |b| sheet.each_header(&b) }.to yield_successive_args(*headers)
     end
   end
 end

--- a/spec/support/shared/sheet/backend_empty.rb
+++ b/spec/support/shared/sheet/backend_empty.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_empty" do |pending_custom_headers: false|
+RSpec.shared_examples "sheet/backend_empty" do
   describe "#each_header" do
     context "with a block" do
       it "doesn't yield" do
@@ -65,7 +65,7 @@ RSpec.shared_examples "sheet/backend_empty" do |pending_custom_headers: false|
     end
   end
 
-  context "when headers are customized", pending: pending_custom_headers do
+  context "when headers are customized" do
     let(:headers_data) do
       %w[foo bar baz]
     end

--- a/spec/support/shared/sheet/backend_filled.rb
+++ b/spec/support/shared/sheet/backend_filled.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_filled" do
+RSpec.shared_examples "sheet/backend_filled" do |pending_custom_headers: false|
   unless instance_methods.include?(:source_data)
     alias_method :source_data, :source
   end
@@ -74,6 +74,55 @@ RSpec.shared_examples "sheet/backend_filled" do
 
     it "can't enumerate rows" do
       expect { sheet.each_row }.to raise_error(Sheetah::Sheet::ClosureError)
+    end
+  end
+
+  context "when headers are customized", pending: pending_custom_headers do
+    let(:data_size) { source_data[0].size }
+    let(:headers_size) { data_size + diff }
+
+    let(:headers_data) do
+      Array.new(headers_size) { |i| "header#{i}" }
+    end
+
+    let(:sheet_opts) do
+      super().merge(headers: headers_data)
+    end
+
+    context "when their size is equal to the size of the data" do
+      let(:diff) { 0 }
+
+      it "relies on the custom headers" do
+        headers = build_headers(headers_data)
+        expect { |b| sheet.each_header(&b) }.to yield_successive_args(*headers)
+      end
+
+      it "treats all rows as data" do
+        rows = build_rows(source_data, row: 1)
+        expect { |b| sheet.each_row(&b) }.to yield_successive_args(*rows)
+      end
+    end
+
+    context "when their size is smaller than the size of the data" do
+      let(:diff) { -1 }
+
+      it "fails to initialize", autoclose_sheet: false do
+        expect { sheet }.to raise_error(
+          Sheetah::Sheet::TooFewHeaders,
+          "Expected #{data_size} headers, got: #{headers_size}"
+        )
+      end
+    end
+
+    context "when their size is larger than the size of the data" do
+      let(:diff) { 1 }
+
+      it "fails to initialize", autoclose_sheet: false do
+        expect { sheet }.to raise_error(
+          Sheetah::Sheet::TooManyHeaders,
+          "Expected #{data_size} headers, got: #{headers_size}"
+        )
+      end
     end
   end
 end

--- a/spec/support/shared/sheet/backend_filled.rb
+++ b/spec/support/shared/sheet/backend_filled.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_filled" do |pending_custom_headers: false|
+RSpec.shared_examples "sheet/backend_filled" do
   unless instance_methods.include?(:source_data)
     alias_method :source_data, :source
   end
@@ -77,7 +77,7 @@ RSpec.shared_examples "sheet/backend_filled" do |pending_custom_headers: false|
     end
   end
 
-  context "when headers are customized", pending: pending_custom_headers do
+  context "when headers are customized" do
     let(:data_size) { source_data[0].size }
     let(:headers_size) { data_size + diff }
 


### PR DESCRIPTION
Backends now accept custom headers, instead of always having to rely on the first row in the document.

Custom headers are opt-in, and their size must be consistent with the size of a row in the document.