### PR TITLE
Opt-in sizable rows enumerator

### DIFF
--- a/lib/sheetah/backends/wrapper.rb
+++ b/lib/sheetah/backends/wrapper.rb
@@ -34,7 +34,7 @@ module Sheetah
       def each_row
         raise_if_closed
 
-        return to_enum(:each_row) unless block_given?
+        return to_enum(:each_row) { @rows_count } unless block_given?
 
         @rows_count.times do |row_index|
           row, row_data = read_row(row_index)

--- a/lib/sheetah/backends/xlsx.rb
+++ b/lib/sheetah/backends/xlsx.rb
@@ -44,7 +44,7 @@ module Sheetah
       def each_row
         raise_if_closed
 
-        return to_enum(:each_row) unless block_given?
+        return to_enum(:each_row) { @rows_count } unless block_given?
 
         @rows_count.times do |row_index|
           row = @rows.name(row_index)

--- a/spec/sheetah/backends/wrapper_spec.rb
+++ b/spec/sheetah/backends/wrapper_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Sheetah::Backends::Wrapper do
       []
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", sized_rows_enum: true
   end
 
   context "when the input table is filled" do
@@ -86,6 +86,6 @@ RSpec.describe Sheetah::Backends::Wrapper do
       end.freeze
     end
 
-    include_examples "sheet/backend_filled"
+    include_examples "sheet/backend_filled", sized_rows_enum: true
   end
 end

--- a/spec/sheetah/backends/xlsx_spec.rb
+++ b/spec/sheetah/backends/xlsx_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       []
     end
 
-    include_examples "sheet/backend_empty"
+    include_examples "sheet/backend_empty", sized_rows_enum: true
   end
 
   context "when the input table is filled" do
@@ -53,7 +53,7 @@ RSpec.describe Sheetah::Backends::Xlsx do
       ]
     end
 
-    include_examples "sheet/backend_filled"
+    include_examples "sheet/backend_filled", sized_rows_enum: true
   end
 
   context "when the input table includes empty rows around the content" do

--- a/spec/support/shared/sheet/backend_empty.rb
+++ b/spec/support/shared/sheet/backend_empty.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_empty" do
+RSpec.shared_examples "sheet/backend_empty" do |sized_rows_enum: false|
   describe "#each_header" do
     context "with a block" do
       it "doesn't yield" do
@@ -41,7 +41,7 @@ RSpec.shared_examples "sheet/backend_empty" do
         enum = sheet.each_row
 
         expect(enum).to be_a(Enumerator)
-        expect(enum.size).to be_nil
+        expect(enum.size).to eq(sized_rows_enum ? 0 : nil)
         expect(enum.to_a).to eq([])
       end
     end

--- a/spec/support/shared/sheet/backend_filled.rb
+++ b/spec/support/shared/sheet/backend_filled.rb
@@ -2,7 +2,7 @@
 
 require "sheetah/sheet"
 
-RSpec.shared_examples "sheet/backend_filled" do
+RSpec.shared_examples "sheet/backend_filled" do |sized_rows_enum: false|
   unless instance_methods.include?(:source_data)
     alias_method :source_data, :source
   end
@@ -53,7 +53,7 @@ RSpec.shared_examples "sheet/backend_filled" do
         enum = sheet.each_row
 
         expect(enum).to be_a(Enumerator)
-        expect(enum.size).to be_nil
+        expect(enum.size).to eq(sized_rows_enum ? rows.size : nil)
         expect(enum.to_a).to eq(rows)
       end
     end


### PR DESCRIPTION
Depending on the internal details of a backend, it might be possible to know how many rows the document has before enumerating them all.

In such cases, we want an enumerator returned by `#each_row` to return that number (instead of `nil`) when its `#size` method is called. A use case for this could be for users of the library to validate that a document doesn't exceed a certain size before processing it.

That being said, implementers of backends should remember that sizable enumerators of rows are opt-in. The goal of this library is to be reasonably efficient with large documents, and it wouldn't make sense to slurp a whole document into memory only to calculate its size.