### PR TITLE
Simplify requiring the Messaging library

### DIFF
--- a/lib/tabulard/messaging.rb
+++ b/lib/tabulard/messaging.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
+require_relative "messaging/config"
+require_relative "messaging/constants"
+require_relative "messaging/message"
+require_relative "messaging/message_variant"
+require_relative "messaging/messenger"
+
 module Tabulard
   module Messaging
-    require_relative "messaging/config"
-    require_relative "messaging/constants"
-    require_relative "messaging/message"
-    require_relative "messaging/message_variant"
-    require_relative "messaging/messenger"
-
     class << self
       attr_accessor :config
 

--- a/lib/tabulard/messaging.rb
+++ b/lib/tabulard/messaging.rb
@@ -5,6 +5,7 @@ module Tabulard
     require_relative "messaging/config"
     require_relative "messaging/constants"
     require_relative "messaging/message"
+    require_relative "messaging/message_variant"
     require_relative "messaging/messenger"
 
     class << self

--- a/lib/tabulard/table.rb
+++ b/lib/tabulard/table.rb
@@ -2,8 +2,7 @@
 
 require_relative "table/col_converter"
 require_relative "errors/error"
-require_relative "messaging/messenger"
-require_relative "messaging/message_variant"
+require_relative "messaging"
 require_relative "utils/monadic_result"
 
 module Tabulard


### PR DESCRIPTION
- `require "tabulard/messaging"` will now also define `Tabulard::Messaging::MessageVariant`.
- also, the calls to `require` in `lib/tabulard/messaging.rb` are now more conventional.